### PR TITLE
Add KeyHolder for replacing the old KeyType type

### DIFF
--- a/src/key.rs
+++ b/src/key.rs
@@ -1,0 +1,41 @@
+use std::hash::Hash;
+
+#[derive(PartialEq, Hash, Debug)]
+pub enum KeyHolder<T> {
+    Key(T),
+    Tombstone,
+}
+
+impl<T: PartialEq> KeyHolder<T> {
+    pub fn is_tombstone(&self) -> bool {
+        *self == KeyHolder::Tombstone
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::KeyHolder;
+
+    #[test]
+    fn test_keyholder_key_eq() {
+        let k1 = KeyHolder::Key(String::from("abc"));
+        let k2 = KeyHolder::Key(String::from("abc"));
+        assert_eq!(k1, k2);
+        println!("{:?}", k1);
+    }
+
+    #[test]
+    fn test_keyholder_is_tombstone() {
+        let k1 = KeyHolder::Key(String::from("abc"));
+        assert!(!k1.is_tombstone());
+        assert!(KeyHolder::<&str>::Tombstone.is_tombstone());
+    }
+
+    #[test]
+    fn test_keyholder_eq() {
+        let k1 = KeyHolder::Key("abc");
+        assert_ne!(k1, KeyHolder::Tombstone);
+        let k2 = KeyHolder::<i32>::Tombstone;
+        assert_eq!(KeyHolder::Tombstone, k2);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ use std::time::{Duration, Instant};
 
 mod keyvalue;
 mod kvtable;
+mod key;
 
 use crate::keyvalue::{
     Key, KeyTypes::KeyEmpty, KeyTypes::KeyTombStone, KeyTypes::KeyType, Value,
@@ -174,7 +175,6 @@ impl<K: Eq + Hash, V: Eq> NonBlockingHashMap<K, V> {
                 // impossible
                 panic!("_chm._newkvs changed by unknown thread");
             }
-            self.rehash();
             newkvs_alloc
         } else {
             // wait for the allocating thread to finish its job
@@ -647,12 +647,6 @@ impl<K: Eq + Hash, V: Eq> NonBlockingHashMap<K, V> {
             }
         }
     }
-
-    unsafe fn fast_keyeq(k: *mut Key<K>, hashk: u64, key: *mut Key<K>, hashkey: u64) -> bool {
-        k == key || ((hashk == 0 || hashk == hashkey) && !(*k).is_tombstone() && (*key) == (*k))
-    }
-
-    pub fn rehash(&self) {}
 
     pub fn capacity(&self) -> usize {
         unsafe { (*self._kvs.load(MEMORY_ORDERING)).len() }


### PR DESCRIPTION
Having two nested raw pointers (raw *T in KeyType and raw *KeyType in
AtomicPtr) is unnecessary - should just follow Rust's move semantics for
keys/values. This will also help with solving #5 

Also, to have _ks as a vector of AtomicPtr adds one unnecessary indirection.
A more ideal solution would be to define _ks as `Vec<* mut KeyHolder<T>>`
and run intrinsic CAS on _ks slots directly. `null_mut()` will naturally represents
empty slots, so allocating new _ks will no longer need an explicit loop to initialize
it.
    
Also remove unused methods in lib.rs ported from Java NBHM.